### PR TITLE
Bootstrap fhirstore on startup

### DIFF
--- a/fhir-api/db/__init__.py
+++ b/fhir-api/db/__init__.py
@@ -47,6 +47,8 @@ def get_store():
         store = fhirstore.FHIRStore(connection, DB_NAME)
         if not cached_resources:
             store.resume()
+            if len(store.resources) == 0:
+                store.bootstrap(depth=3)
             cached_resources = store.resources
         else:
             store.resources = cached_resources


### PR DESCRIPTION
This should bootstrap the store when the database is empty.

Previously, we only fetched collections from an already-initialized database.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/arkhn/warehouse-api/23)
<!-- Reviewable:end -->
